### PR TITLE
v0.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,9 +43,9 @@ test:
     - pip
 
 about:
-  home: https://share.streamlit.app/
+  home: https://share.streamlit.io/
   dev_url: https://pypi.org/project/streamlit-extras/
-  doc_url: https://share.streamlit.app/
+  doc_url: https://share.streamlit.io/
   summary: A library to discover, try, install and share Streamlit extras
   description: |
     streamlit-extras is a Python library putting together useful Streamlit bits of code (extras).

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,58 @@
+{% set name = "streamlit-extras" %}
+{% set version = "0.2.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/streamlit_extras-{{ version }}.tar.gz
+  sha256: ad0d559cb8d36f4e9fee03cb9b742d836bfd6ed2ea8d4a49e7aac5e590f643ec
+
+build:
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+  # s390x is missing streamlit
+  skip: true  # [py<38 or s390x]
+
+requirements:
+  host:
+    - python
+    - poetry-core
+    - pip
+    - setuptools
+    - wheel
+  run:
+    - python <3.9.7|>3.9.7,<4.0
+    - streamlit >=1.0.0
+    - st-annotated-text >=3.0.0
+    - streamlit-embedcode >=0.1.2
+    - streamlit-keyup >=0.1.9
+    - protobuf !=3.20.2
+    - streamlit-camera-input-live >=0.2.0
+    - streamlit-vertical-slider >=1.0.2
+    - streamlit-toggle-switch >=1.0.2
+    - htbuilder 0.6.1
+
+test:
+  imports:
+    - streamlit_extras
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://share.streamlit.app/
+  dev_url: https://pypi.org/project/streamlit-extras/
+  doc_url: https://share.streamlit.app/
+  summary: A library to discover, try, install and share Streamlit extras
+  description: |
+    streamlit-extras is a Python library putting together useful Streamlit bits of code (extras).
+  license: Apache-2.0
+  license_file: LICENSE
+  license_family: Apache
+
+extra:
+  recipe-maintainers:
+    - ELundby45


### PR DESCRIPTION
upstream: https://github.com/arnaudmiribel/streamlit-extras/tree/v0.2.0

`streamlit-extras v0.2.7`-> `mardownlit`-> `streamlit-faker` -> `streamlit-extras 0.2.0`

## Notes
- This is an intentionally old version of streamlit-extras. This is in order to work around a cyclical dependency with `streamlit-faker` and `markdownlit` with the latest version of streamlit-extras
- This is a new feedstock
- Upstream [notes](https://github.com/arnaudmiribel/streamlit-extras/blob/v0.2.0/pyproject.toml#L22) that streamlit doesn't work with python 3.9.7, this is the reason for the run pinnings and linter error.  