### PR TITLE
v0.2.7

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sfe1ed40
+
+channels:
+  - sfe1ed40

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-upload_channels:
-  - sfe1ed40
-
-channels:
-  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "streamlit-extras" %}
-{% set version = "0.2.0" %}
+{% set version = "0.2.7" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/streamlit_extras-{{ version }}.tar.gz
-  sha256: ad0d559cb8d36f4e9fee03cb9b742d836bfd6ed2ea8d4a49e7aac5e590f643ec
+  sha256: 52a8cb3a4394735ee873c92c95fabf56d84cc2400ed0617bbc8b8259c0560276
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
@@ -33,6 +33,10 @@ requirements:
     - streamlit-vertical-slider >=1.0.2
     - streamlit-toggle-switch >=1.0.2
     - htbuilder 0.6.1
+    - streamlit-faker >=0.0.2
+    - streamlit-card >=0.0.4
+    - markdownlit >=0.0.5
+    - streamlit-image-coordinates >=0.1.1,<1.0.0
 
 test:
   imports:


### PR DESCRIPTION
upstream: https://github.com/arnaudmiribel/streamlit-extras/tree/v0.2.7

## Notes
- Upstream [notes](https://github.com/arnaudmiribel/streamlit-extras/blob/v0.2.0/pyproject.toml#L22) that streamlit doesn't work with python 3.9.7, this is the reason for the run pinnings and linter error.  
- Upon approval this will be uploaded to the Snowflake channel. 