### PR TITLE
rebuild v 0.2.7:

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,8 @@ source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/streamlit_extras-{{ version }}.tar.gz
   sha256: 52a8cb3a4394735ee873c92c95fabf56d84cc2400ed0617bbc8b8259c0560276
   patches:
+    # entrypoints is a package in maintenance mode that seems to be implicitly used by streamlit-extras. It seems to be 
+    # not really needed. Rather than adding entrypoints to the runtime dependencies, it was decided to remove it from the implementation.
     - patches/0001-remove-the-usage-of-entrypoints.patch
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,14 +8,20 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/streamlit_extras-{{ version }}.tar.gz
   sha256: 52a8cb3a4394735ee873c92c95fabf56d84cc2400ed0617bbc8b8259c0560276
+  patches:
+    - patches/0001-remove-the-usage-of-entrypoints.patch
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
   # s390x is missing streamlit
   skip: true  # [py<38 or s390x]
 
+
 requirements:
+  build:
+    - patch  # [not win]
+    - m2-patch  # [win]
   host:
     - python
     - poetry-core
@@ -23,7 +29,7 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python <3.9.7|>3.9.7,<4.0
+    - python <3.9.7,>3.9.7,<4.0
     - streamlit >=1.0.0
     - st-annotated-text >=3.0.0
     - streamlit-embedcode >=0.1.2

--- a/recipe/patches/0001-remove-the-usage-of-entrypoints.patch
+++ b/recipe/patches/0001-remove-the-usage-of-entrypoints.patch
@@ -1,0 +1,42 @@
+diff --git a/src/streamlit_extras/altex/__init__.py b/src/streamlit_extras/altex/__init__.py
+index f6fd95d..8b8e09f 100644
+--- a/src/streamlit_extras/altex/__init__.py
++++ b/src/streamlit_extras/altex/__init__.py
+@@ -2,7 +2,6 @@ from functools import partial
+ from typing import Optional, Union
+
+ import altair as alt
+-import entrypoints
+ import numpy as np
+ import pandas as pd
+ import streamlit as st
+@@ -171,7 +170,7 @@ def _chart(
+
+     try:
+         alt.themes.enable("streamlit")
+-    except entrypoints.NoSuchEntryPoint:
++    except:
+         st.altair_chart = partial(st.altair_chart, theme="streamlit")
+
+     x_ = _get_shorthand(x)
+diff --git a/src/streamlit_extras/chart_annotations/__init__.py b/src/streamlit_extras/chart_annotations/__init__.py
+index 1edf4ff..fb3374f 100644
+--- a/src/streamlit_extras/chart_annotations/__init__.py
++++ b/src/streamlit_extras/chart_annotations/__init__.py
+@@ -4,7 +4,6 @@ from functools import partial
+ from typing import Iterable, Tuple
+
+ import altair as alt
+-import entrypoints
+ import pandas as pd
+ import streamlit as st
+
+@@ -17,7 +16,7 @@ from .. import extra
+
+ try:
+     alt.themes.enable("streamlit")
+-except entrypoints.NoSuchEntryPoint:
++except:
+     st.altair_chart = partial(st.altair_chart, theme="streamlit")
+
+


### PR DESCRIPTION
 - build number increased.
 - patch added to remove entrypoints dependency.
- python pinning modified

The issue was actually observed when doing some tests for streamlit-faker and not streamlit-extras. But it is streamlit-extras that needs some patching. 

streamlit-extras and streamlit are both used by streamlit-faker. With the latest streamlit 1.24.1  (https://github.com/AnacondaRecipes/streamlit-feedstock/pull/5), streamlit-faker started to fail:

`Traceback (most recent call last):
  File "/Users/antonkabanovs/wkspaces/streamlit-faker/streamlit-faker_1689070809379/test_tmp/run_test.py", line 2, in <module>
    import streamlit_faker
  File "/Users/antonkabanovs/wkspaces/streamlit-faker/streamlit-faker_1689070809379/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeho/lib/python3.10/site-packages/streamlit_faker/__init__.py", line 3, in <module>
import: 'streamlit_faker'
    from .chart import StreamlitChartProvider
  File "/Users/antonkabanovs/wkspaces/streamlit-faker/streamlit-faker_1689070809379/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeho/lib/python3.10/site-packages/streamlit_faker/chart.py", line 7, in <module>
    from streamlit_extras import altex
  File "/Users/antonkabanovs/wkspaces/streamlit-faker/streamlit-faker_1689070809379/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeho/lib/python3.10/site-packages/streamlit_extras/altex/__init__.py", line 5, in <module>
    import entrypoints
ModuleNotFoundError: No module named 'entrypoints'`

So the problem is that now nothing provides entrypoints. 
It turns out that the old streamlit v 1.16.0 used altair with version range >=3.2.0<5, resolving into 4.1.0 and taken from noarch:
altair-4.1.0-py_1.tar.bz2
    ├──entrypoints
    ├──jinja2
    ├──jsonschema
    ├──numpy >=0.18
    ├──pandas
    ├──python >=3.6
    └──toolz
    
Now, the new streamlit 1.24.1, which is going to be delivered,  uses altair with range >=4.0,<6. This range resolves into altair v 5.0.1 available on osx-arm64 arch directly. Here are it's runtime dependencies:
altair-5.0.1-py311hca03da5_0.tar.bz2
    ├──jinja2
    ├──jsonschema >=3.0
    ├──numpy
    ├──pandas >=0.18
    ├──python >=3.11,<3.12.0a0
    └──toolz
  
It can be seen that altair 5.0.1 does not have entrypoints as a dependency (and it should not, I checked) while altair 4.1.0 had entrypoints as a runtime dependency.
 
It is a bit of a mess. In short - altair 4.1.0  provides entrypoints (which is why previously there was no issue), but not the altair v 5.0.1 that the new streamlit 1.24.1 requires, which as a result breaks streamlit-extras and streamlit-faker.

It was decided to patch up streamlit-extras to remove entrypoints dependency, as this package is in maintenance mode and just used in a few places. Also, entrypoints is not explicitly mentioned as a dependency in streamlit-extras.