### PR TITLE
rebuild of 0.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - patch       # [not win]
     - m2-patch    # [win]
   host:
-    - python !=3.9.7
+    - python
     - poetry-core
     - pip
     - setuptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,9 @@ requirements:
     - wheel
   run:
     - python !=3.9.7
+    # Only to make conda-build happy... Without this it's not able to see that the package has
+    # to be built for all python versions.
+    - python
     - entrypoints >=0.4
     - streamlit >=1.0.0
     - st-annotated-text >=3.0.0
@@ -67,7 +70,7 @@ test:
 about:
   home: https://share.streamlit.io/
   dev_url: https://github.com/arnaudmiribel/streamlit-extras
-  doc_url:  https://github.com/arnaudmiribel/streamlit-extras
+  doc_url: https://github.com/arnaudmiribel/streamlit-extras
   summary: A library to discover, try, install and share Streamlit extras
   description: |
     streamlit-extras is a Python library putting together useful Streamlit bits of code (extras).


### PR DESCRIPTION
streamlit-extras 0.4.0 :snowflake:

**Destination channel:** defaults

Rebuild of PR #4 due to not building all versions of python on architectures.

### Links

- [PKG-4348](https://anaconda.atlassian.net/browse/PKG-4348) 
- [Upstream repository](https://github.com/arnaudmiribel/streamlit-extras)
- [Upstream changelog/diff](https://github.com/arnaudmiribel/streamlit-extras/compare/v0.2.7...v0.4.1)

### Explanation of changes:

- Updated SHA and Version number
- removed patch and patch dependencies
- reset build number
- added `entrypoints` dependency
- added `htbuilder`
- added `prometheus_client`
- removed python pinning
- updated dev url


[PKG-4348]: https://anaconda.atlassian.net/browse/PKG-4348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ