### PR TITLE
Update version to 0.7.8

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,4 @@
 build_parameters:
   - "--no-test"
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,2 @@
 build_parameters:
   - "--no-test"
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,16 +17,13 @@ build:
   skip: true  # [py<39 or py>=314]
 
 requirements:
-  build:
-    - patch  # [not win]
-    - m2-patch  # [win]
   host:
     - pip
     - python
-    - poetry-core
     - hatchling
   run:
     - python
+    - altex >=0.2.0
     - streamlit >=1.37.0,<1.40.0
     - prometheus_client >=0.20.0
     - st-annotated-text >=4.0.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: true  # [py<39]
+  skip: true  # [py<39 or py>=314]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "streamlit-extras" %}
-{% set version = "0.6.0" %}
+{% set version = "0.7.8" %}
 
 package:
   name: {{ name|lower }}
@@ -7,14 +7,14 @@ package:
 
 source:
   url: https://github.com/arnaudmiribel/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: a41cadb69a773f496596b416c291fef475620170b2b800337f005e7f9bf0849c
+  sha256: f497b2e1a24816ac4a65087f5e32617e3d888f993da321c034039a18c6cf37cb
   patches:
     - patch/0001-downgrade-htbuilder-lowerbound.patch
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: true  # [py<38]
+  skip: true  # [py<39]
 
 requirements:
   build:
@@ -24,34 +24,33 @@ requirements:
     - pip
     - python
     - poetry-core
+    - hatchling
   run:
     - python
-    - streamlit >=1.0.0
-    - st-annotated-text >=3.0.0
+    - streamlit >=1.37.0,<1.40.0
+    - prometheus_client >=0.20.0
+    - st-annotated-text >=4.0.1
+    - st-theme >=1.2.3
     - streamlit-embedcode >=0.1.2
-    - streamlit-keyup >=0.1.9
-    - protobuf !=3.20.2
+    - streamlit-keyup >=0.2.4
+    - protobuf >=5.27.3
     - streamlit-camera-input-live >=0.2.0
     - streamlit-vertical-slider >=2.5.5
     - streamlit-toggle-switch >=1.0.2
     # Temporarily diverging from upstream to fix a conflict that happens in a circular dependency.
     - htbuilder 0.6.1
-    - streamlit-faker >=0.0.2
-    - streamlit-card >=0.0.4
-    - markdownlit >=0.0.5
-    - streamlit-image-coordinates >=0.1.1,<0.2.0
+    - streamlit-faker >=0.0.3
+    - streamlit-card >=1.0.2
+    - markdownlit >=0.0.7
+    - streamlit-image-coordinates >=0.1.9
+    - snowflake-snowpark-python >=1.30.0
     - entrypoints >=0.4
     - prometheus_client >=0.14.0
     - st-theme >=1.0.1
-    - validators >=0.20.0
-    - plotly >=1.0.0
+    - validators >=0.33.0
+    - plotly >=5.23.0
     - streamlit-avatar >=0.1.3
-  run_constrained:
-    - python !=3.9.7
-
-# >   @st.experimental_memo
-# E   AttributeError: module 'streamlit' has no attribute 'experimental_memo'
-{% set ignore_tests = " --ignore=tests/test_extras.py" %}
+    - streamlit-notify >=0.3.1
 
 test:
   source_files:
@@ -60,14 +59,14 @@ test:
     - streamlit_extras
   commands:
     - pip check
-    - pytest -v {{ ignore_tests }} tests
+    - pytest -v tests
   requires:
     - pip
     - pytest
     - pandas
 
 about:
-  home: https://share.streamlit.io/
+  home: https://share.streamlit.io
   summary: A library to discover, try, install and share Streamlit extras
   license: Apache-2.0
   license_family: Apache

--- a/recipe/patch/0001-downgrade-htbuilder-lowerbound.patch
+++ b/recipe/patch/0001-downgrade-htbuilder-lowerbound.patch
@@ -8,18 +8,15 @@ Subject: [PATCH] downgrade htbuilder lowerbound
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/pyproject.toml b/pyproject.toml
-index 1657cc3..901cd8e 100644
+index c0fe64e..00bd426 100644
 --- a/pyproject.toml
 +++ b/pyproject.toml
-@@ -26,7 +26,7 @@ protobuf = "!=3.20.2"
- streamlit-camera-input-live = ">=0.2.0"
- streamlit-vertical-slider = ">=2.5.5"
- streamlit-toggle-switch = ">=1.0.2"
--htbuilder = ">=0.6.2"
-+htbuilder = ">=0.6.1"
- streamlit-faker = ">=0.0.2"
- streamlit-card = ">=0.0.4"
- markdownlit = ">=0.0.5"
--- 
-2.39.3 (Apple Git-146)
-
+@@ -15,7 +15,7 @@ keywords = ["python", "streamlit", "ui", "data"]
+ dependencies = [
+   "altex>=0.2.0",
+   "entrypoints >= 0.4",
+-  "htbuilder >= 0.6.2",
++  "htbuilder >= 0.6.1",
+   "markdownlit >= 0.0.7",
+   "plotly >= 5.23.0",
+   "prometheus-client >= 0.20.0",


### PR DESCRIPTION
streamlit-extras 0.7.8

**Destination channel:**  defaults

### Links

- [PKG-12387](https://anaconda.atlassian.net/browse/PKG-12387) 
- [Upstream repository](https://github.com/arnaudmiribel/streamlit-extras)
### Explanation of changes:

- New version number
- Update patch
- Limit streamlit version because of incompatibility with newer versions (>1.40)


[PKG-12387]: https://anaconda.atlassian.net/browse/PKG-12387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ